### PR TITLE
Use return instead of exit in proxy script

### DIFF
--- a/proxy
+++ b/proxy
@@ -5,7 +5,7 @@ if [[ ! -f /etc/profile.d/proxy ]]; then
   echo 'Create the file and ensure is exports http_proxy'
   echo "For example, run the following command, replacing 'my_proxy:8080' with your proxy:"
   echo "echo 'export http_proxy=my_proxy:8080' >/etc/profile.d/proxy"
-  exit 1
+  return
 fi
 
 source /etc/profile.d/proxy

--- a/proxy
+++ b/proxy
@@ -5,7 +5,7 @@ if [[ ! -f /etc/profile.d/proxy ]]; then
   echo 'Create the file and ensure is exports http_proxy'
   echo "For example, run the following command, replacing 'my_proxy:8080' with your proxy:"
   echo "echo 'export http_proxy=my_proxy:8080' >/etc/profile.d/proxy"
-  return
+  return 1
 fi
 
 source /etc/profile.d/proxy


### PR DESCRIPTION
Otherwise when the script fails your current shell is terminated and you can't see the resulting error messages.