### PR TITLE
Only set / unset environment variables for proxies

### DIFF
--- a/proxy
+++ b/proxy
@@ -19,15 +19,6 @@ if [[ "$1" == "on" ]]; then
 	export HTTP_PROXY=$proxy
 	export HTTPS_PROXY=$proxy
 
-	git config --global http.proxy $proxy                                         &>/dev/null
-	git config --global https.proxy $proxy                                        &>/dev/null
-
-	npm config set proxy $proxy                                                   &>/dev/null
-	npm config set https-proxy $proxy                                             &>/dev/null
-
-	sed -i.bak 's|"proxy": ""|"proxy": "'"$proxy"'"|g' $HOME/.bowerrc             &>/dev/null
-	sed -i.bak 's|"https-proxy": ""|"https-proxy": "'"$proxy"'"|g' $HOME/.bowerrc &>/dev/null
-
 else
 	echo "Disabling proxies"
 
@@ -35,13 +26,4 @@ else
 	unset https_proxy
 	unset HTTP_PROXY
 	unset HTTPS_PROXY
-
-	git config --global --unset http.proxy                                        &>/dev/null
-	git config --global --unset https.proxy                                       &>/dev/null
-
-	npm config rm proxy                                                           &>/dev/null
-	npm config rm https-proxy                                                     &>/dev/null
-
-	sed -i.bak 's|"proxy": "'"$proxy"'"|"proxy": ""|g' $HOME/.bowerrc             &>/dev/null
-	sed -i.bak 's|"https-proxy": "'"$proxy"'"|"https-proxy": ""|g' $HOME/.bowerrc &>/dev/null
 fi


### PR DESCRIPTION
As far as I can tell git. NPM and bower all respect the environment variables when using HTTP proxies so the extra config is unnecessary (and slows the command down considerably).